### PR TITLE
configure.ac: fix build with rockchip-mali

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,7 +84,7 @@ AS_IF([test "x$enable_strict_gles" = "xyes"], [
 ])
 
 PKG_CHECK_MODULES([egl], [egl >= 1])
-PKG_CHECK_MODULES([glesv2], [glesv2 >= 1])
+PKG_CHECK_MODULES([glesv2], [glesv2])
 
 AC_CHECK_HEADERS([EGL/eglext.h], [], [],
 [[#include <EGL/egl.h>


### PR DESCRIPTION
Don't check glesv2 version in `glesv2.pc` file to avoid the following build failure with rockchip-mali:

```
checking for glesv2... no
configure: error: Package requirements (glesv2 >= 1) were not met:

Package dependency requirement 'glesv2 >= 1' could not be satisfied. Package 'glesv2' has version '', required version is '>= 1'

Consider adjusting the PKG_CONFIG_PATH environment variable if you installed software in a non-standard prefix.

Alternatively, you may set the environment variables glesv2_CFLAGS and glesv2_LIBS to avoid the need to call pkg-config. See the pkg-config man page for more details.
```

Fixes:
 - http://autobuild.buildroot.org/results/ac765b0ff5f914df4087ae4691fe711dc912f03b